### PR TITLE
Update init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -96,7 +96,7 @@ fi
 echo
 echo "Applying JBoss EAP 6.4.4 patch now..."
 echo
-$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SRC_DIR/$EAP_PATCH"
+$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SRC_DIR/$EAP_PATCH --override-modules"
 
 if [ $? -ne 0 ]; then
 	echo


### PR DESCRIPTION
Seems that the installation of apr from yum in RHEL 7.2 modifies web module and it conflicts when applying patches with the output below:

================================
Applying JBoss EAP 6.4.4 patch now...

Conflicts detected: org.jboss.as.web:main
Use the --override-all, --override=[] or --preserve=[] arguments in order to resolve the conflict.

Error occurred during JBoss EAP patching!
================================

It's solved using --override-modules option when patching though JBoss CLI.