### PR TITLE
Update JBoss BPMSuite installer version in README.

### DIFF
--- a/installs/README
+++ b/installs/README
@@ -2,7 +2,7 @@ Download the following from the JBoss Customer Portal
 
  * EAP installer (jboss-eap-6.4.0-installer.jar)
  * EAP patch (jboss-eap-6.4.4-patch.zip)
- * BPM Suite installer (jboss-bpmsuite-6.2.0.GA-installer.jar)
+ * BPM Suite installer (jboss-bpmsuite-installer-6.2.0.BZ-1299002.jar)
 
 and copy to this directory for the init.sh script to work.
 
@@ -10,5 +10,5 @@ Ensure that this file is executable by running:
 
 chmod +x <path-to-project>/installs/jboss-eap-6.4.0-installer.jar
 chmod +x <path-to-project>/installs/jboss-eap-6.4.4-patch.zip
-chmod +x <path-to-project>/installs/jboss-bpmsuite-6.2.0.GA-installer.jar
+chmod +x <path-to-project>/installs/jboss-bpmsuite-installer-6.2.0.BZ-1299002.jar
 


### PR DESCRIPTION
Small documentation fix in the README file of the install directory. Now points to correct JBoss BPMSuite installer.